### PR TITLE
added error checking for input of two 1-D arrays

### DIFF
--- a/src/wmm2020/base.py
+++ b/src/wmm2020/base.py
@@ -29,9 +29,22 @@ else:
 
 
 def wmm(glats: np.ndarray, glons: np.ndarray, alt_km: float, yeardec: float) -> xarray.Dataset:
+    """
+    wmm computes the value of the world magnetic model at grid points specified by glats and
+    glons, for a single altitude value. glats and glons should be in degrees.
 
-    glats = np.atleast_2d(glats).astype(float)  # to coerce all else to float64
-    glons = np.atleast_2d(glons)
+    glats and glons should be generated from something like np.meshgrid, so they should be
+    2-D arrays. See the example in RunWMM2020.py.
+    """
+
+    glats = np.atleast_2d(glats).astype(np.float64)  # to coerce all else to float64
+    glons = np.atleast_2d(glons).astype(np.float64)
+
+    # the only way to check, if two 1-D arrays are passed in is to examine the values.
+    # expect that lon[:,i] for all i are the same value
+    # expect that lat[i,:] for all i are the same value
+    assert np.allclose(np.diff(glons, axis=0), 0)
+    assert np.allclose(np.diff(glats, axis=1), 0)
 
     assert glats.shape == glons.shape
 


### PR DESCRIPTION
I identified a potential bug in wmm, when called with two 1-D arrays as inputs for glats and glons. 

I believe that I was not using the code as intended, and wanted to give it a list of lat/lon locations along a path, rather than grid coordinates. I called it like this:

```
import wmm2020
wmm2020.wmm( [45.,46.], [90.,91.], 10, 2020.5)
```

and it happily ignored the second latitude value, giving me these results:

```
<xarray.Dataset>
Dimensions:  (glat: 1, glon: 2)
Coordinates:
  * glat     (glat) float64 45.0
  * glon     (glon) float64 90.0 91.0
Data variables:
    north    (glat, glon) float64 2.338e+04 2.34e+04
    east     (glat, glon) float64 852.5 708.1
    down     (glat, glon) float64 5.267e+04 5.276e+04
    total    (glat, glon) float64 5.764e+04 5.772e+04
    incl     (glat, glon) float64 66.05 66.07
    decl     (glat, glon) float64 2.088 1.733
Attributes:
    time:     2020.5
```

The fix was to check that in fact the input lat and lon values are in a meshgrid format, so I added two assert statements to check this. 

I also added a docstring explaining how to use the function. 