### PR TITLE
C Extension that works with pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,4 +5,14 @@ import setuptools
 # PEP517 workaround
 site.ENABLE_USER_SITE = True
 
-setuptools.setup()
+extensions = [
+        setuptools.Extension(
+                'wmm2020.wmm_cext',  # Note: Next wmm_cext.pyd inside of package wmm2020
+                # define_macros=[('MAJOR_VERSION', '1')],
+                # extra_compile_args=['-std=c99'],
+                sources=['src/wmm2020/src/wmm_cext.c', 'src/wmm2020/src/wmm_point_sub.c',
+                         'src/wmm2020/src/GeomagnetismLibrary.c'],
+                include_dirs=['src/wmm2020/src/']),
+    ]
+
+setuptools.setup(ext_modules=extensions)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import sys
 import site
 import setuptools
 
@@ -15,4 +16,9 @@ extensions = [
                 include_dirs=['src/wmm2020/src/']),
     ]
 
-setuptools.setup(ext_modules=extensions)
+try:
+    setuptools.setup(ext_modules=extensions)
+except (Exception, SystemError, SystemExit) as err:
+    # Catch SystemExit to try installing again without C Extension
+    print('Failed to build the C Extension!', file=sys.stderr)  # This will only print with "pip install -v ."
+    setuptools.setup()

--- a/src/wmm2020/__init__.py
+++ b/src/wmm2020/__init__.py
@@ -1,1 +1,1 @@
-from .base import wmm, wmm_point
+from .base import wmm, transect, wmm_point, USING_C_EXT, wmmsub

--- a/src/wmm2020/build.py
+++ b/src/wmm2020/build.py
@@ -9,6 +9,14 @@ from pathlib import Path
 import importlib.resources
 import subprocess
 import sys
+import os
+import ctypes as ct
+
+from .this_path import SDIR
+
+
+__all__ = ['build', 'get_libpath', 'SDIR', 'libwmm',
+           'wmmsub']
 
 
 def build():
@@ -32,3 +40,63 @@ def get_libpath(bin_dir: Path, stem: str) -> Path:
         dllfn = bin_dir / ("lib" + stem + ".dylib")
 
     return dllfn
+
+
+# Build and load the dll
+libwmm = None
+
+
+def load_wmm():
+    """Run the build commands and load the library. The user may want to import this module without building."""
+    global libwmm
+
+    if libwmm is None:
+        BDIR = SDIR / "build"
+
+        # NOTE: must be str() for Windows, even with py37
+        dllfn = get_libpath(BDIR, "wmm20")
+        if not dllfn.is_file():
+            build()
+            dllfn = get_libpath(BDIR, "wmm20")
+            if not dllfn.is_file():
+                raise ModuleNotFoundError(f"could not find {dllfn}")
+
+        libwmm = ct.cdll.LoadLibrary(str(dllfn))
+
+
+def wmmsub(geolatitude, geolongitude, HeightAboveEllipsoid, yeardecimal, wmm_filename=None):
+    # Load the library. This may also build the library the first time.
+    load_wmm()
+
+    # Check WMM filename argument
+    if wmm_filename is None:
+        wmm_filename = SDIR.joinpath('WMM.COF')
+
+    x = ct.c_double()
+    y = ct.c_double()
+    z = ct.c_double()
+    T = ct.c_double()
+    D = ct.c_double()
+    mI = ct.c_double()
+
+    old_dir = os.getcwd()
+    os.chdir(os.path.dirname(wmm_filename))
+    ret = libwmm.wmmsub(
+        ct.c_double(geolatitude),
+        ct.c_double(geolongitude),
+        ct.c_double(HeightAboveEllipsoid),
+        ct.c_double(yeardecimal),
+        ct.byref(x),
+        ct.byref(y),
+        ct.byref(z),
+        ct.byref(T),
+        ct.byref(D),
+        ct.byref(mI),
+    )
+    os.chdir(old_dir)
+
+    # Check for error
+    if ret != 0:
+        raise FileNotFoundError("WMM.COF not found.")  # FileNotFound seems to be the only condition for error
+
+    return x.value, y.value, z.value, T.value, D.value, mI.value

--- a/src/wmm2020/src/wmm_cext.c
+++ b/src/wmm2020/src/wmm_cext.c
@@ -1,0 +1,109 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include "wmm_point_sub.h"
+
+
+static PyObject *
+wmm_cext_wmmsub(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    char* wmm_filename = "WMM.COF";
+    double geolatitude;
+    double geolongitude;
+    double HeightAboveEllipsoid;
+    double yeardecimal;
+    double x;
+    double y;
+    double z;
+    double f;
+    double decl;
+    double incl;
+    int ret;
+
+
+    // Parse the arguments
+    static char *kwlist[] = {"geolatitude", "geolongitude", "HeightAboveEllipsoid", "yeardecimal", "wmm_filename", NULL};
+    if (! PyArg_ParseTupleAndKeywords(args, kwds, "dddd|z", kwlist,
+                                      &geolatitude, &geolongitude, &HeightAboveEllipsoid, &yeardecimal, &wmm_filename))
+        return NULL;
+
+    ret = wmmsub_f(geolatitude, geolongitude, HeightAboveEllipsoid, yeardecimal,
+                   &x, &y, &z, &f, &decl, &incl, wmm_filename);
+
+    if (ret == 0){
+        return Py_BuildValue("(d, d, d, d, d, d)", x, y, z, f, decl, incl);
+    }
+
+    // Raise a error
+    PyErr_SetString(PyExc_FileNotFoundError, "WMM.COF not found.");
+    return NULL;
+}
+
+
+static PyMethodDef wmm_cext_module_methods[] = {
+    {"wmmsub", (PyCFunction)wmm_cext_wmmsub, METH_VARARGS | METH_KEYWORDS,
+     "WMM Point Calculation Program.\n"
+     "\n"
+     "The Geomagnetism Library is used to make a command prompt program. The program prompts\n"
+     "the user to enter a location, performs the computations and prints the results to the\n"
+     "standard output. The program expects the files GeomagnetismLibrary.c, GeomagnetismHeader.h,\n"
+     "WMM.COF and EGM9615.h to be in the same directory.\n"
+     "\n"
+     "Args:\n"
+     "    geolatitude (float): latitude.\n"
+     "    geolongitude (float): longitude.\n"
+     "    HeightAboveEllipsoid (float): .\n"
+     "    yeardecimal (float): .\n"
+     "    wmm_filename (str)['WMM.COF']: Filename that points to the WMM.COF.\n"
+     "\n"
+     "Returns:\n"
+     "    x (float): .\n"
+     "    y (float): .\n"
+     "    z (float): .\n"
+     "    f (float): .\n"
+     "    decl (float): .\n"
+     "    incl (float): .\n"},
+
+    {NULL}  /* Sentinel */
+};
+
+
+// Note: "wmm_cext" is the compiled name. It will compile to "wmm_cext.pyd"
+#if PY_MAJOR_VERSION >= 3
+// Python 3.x
+
+static struct PyModuleDef c2module = {
+    PyModuleDef_HEAD_INIT,
+    "wmm_cext",
+    "WMM Python C Extension.",
+    -1,
+    wmm_cext_module_methods, NULL, NULL, NULL, NULL
+};
+
+
+PyMODINIT_FUNC
+PyInit_wmm_cext(void)
+{
+    PyObject* m;
+
+    m = PyModule_Create(&c2module);
+    if (m == NULL) return NULL;
+
+    return m;
+}
+
+#else
+// Python 2.7
+#define INITERROR return
+
+
+PyMODINIT_FUNC
+init_wmm_cext(void)
+{
+    PyObject* m;
+
+    m = Py_InitModule("wmm_ext", wmm_ext_module_methods);
+    if (m == NULL) return;
+}
+
+#endif

--- a/src/wmm2020/src/wmm_point_sub.c
+++ b/src/wmm2020/src/wmm_point_sub.c
@@ -28,8 +28,8 @@ April 21, 2011
  *  Last changed on: $Date: 2014-11-21 10:40:43 -0700 (Fri, 21 Nov 2014) $
  */
 
-int wmmsub(double geolatitude, double geolongitude, double HeightAboveEllipsoid, double yeardecimal,
-           double* X, double* Y, double* Z, double* F, double* Decl, double* Incl)
+int wmmsub_f(double geolatitude, double geolongitude, double HeightAboveEllipsoid, double yeardecimal,
+             double* X, double* Y, double* Z, double* F, double* Decl, double* Incl, char* filename)
 {
     MAGtype_MagneticModel * MagneticModels[1], *TimedMagneticModel;
     MAGtype_Ellipsoid Ellip;
@@ -39,7 +39,6 @@ int wmmsub(double geolatitude, double geolongitude, double HeightAboveEllipsoid,
     MAGtype_GeoMagneticElements GeoMagneticElements,Errors;
     MAGtype_Geoid Geoid;
     char ans[20], b;
-    char filename[] = "WMM.COF";
     char VersionDate_Large[] = "$Date: 2014-11-21 10:40:43 -0700 (Fri, 21 Nov 2014) $";
     char VersionDate[12];
     int NumTerms, Flag = 1, nMax = 0;
@@ -98,4 +97,12 @@ int wmmsub(double geolatitude, double geolongitude, double HeightAboveEllipsoid,
     *Incl = GeoMagneticElements.Incl;
 
     return EXIT_SUCCESS;
+}
+
+
+int wmmsub(double geolatitude, double geolongitude, double HeightAboveEllipsoid, double yeardecimal,
+           double* X, double* Y, double* Z, double* F, double* Decl, double* Incl)
+{
+    return wmmsub(geolatitude, geolongitude, HeightAboveEllipsoid, yeardecimal,
+                  X, Y, Z, F, Decl, Incl, "WMM.COF");
 }

--- a/src/wmm2020/src/wmm_point_sub.h
+++ b/src/wmm2020/src/wmm_point_sub.h
@@ -1,0 +1,23 @@
+#ifndef WMM_POINT_SUB_H
+#define WMM_POINT_SUB_H
+
+
+/*
+WMM Point Calculation Program.
+The Geomagnetism Library is used to make a command prompt program. The program prompts
+the user to enter a location, performs the computations and prints the results to the
+standard output. The program expects the files GeomagnetismLibrary.c, GeomagnetismHeader.h,
+WMM.COF and EGM9615.h to be in the same directory.
+Manoj.C.Nair@Noaa.Gov
+April 21, 2011
+ *  Revision Number: $Revision: 1270 $
+ *  Last changed by: $Author: awoods $
+ *  Last changed on: $Date: 2014-11-21 10:40:43 -0700 (Fri, 21 Nov 2014) $
+ */
+int wmmsub_f(double geolatitude, double geolongitude, double HeightAboveEllipsoid, double yeardecimal,
+             double* X, double* Y, double* Z, double* F, double* Decl, double* Incl, char* filename);
+
+int wmmsub(double geolatitude, double geolongitude, double HeightAboveEllipsoid, double yeardecimal,
+              double* X, double* Y, double* Z, double* F, double* Decl, double* Incl);
+
+#endif  // WMM_POINT_SUB_H

--- a/src/wmm2020/this_path.py
+++ b/src/wmm2020/this_path.py
@@ -1,0 +1,22 @@
+"""Get the path of this directory. Ugh."""
+# Find the source directory that holds WMM.COF
+try:  # Doesn't exists on all Python Versions
+    import importlib.resources
+    SDIR = importlib.resources.files('wmm2020')
+except (NameError, Exception):
+    try:  # Not really good for executables.
+        from pathlib import Path
+        SDIR = Path(__file__).parent
+    except (ImportError, Exception):
+        try:  # Compatibility support
+            import importlib_resources
+            SDIR = importlib_resources.files('wmm2020')
+        except (ImportError, Exception):
+            try:  # Compatibility support
+                import resource_man
+                SDIR = resource_man.files('wmm2020')
+            except (ImportError, Exception):
+                SDIR = Path()
+
+
+__all__ = ['SDIR']


### PR DESCRIPTION

I created a C Extension. If you have the Visual Studio compilers installed, you can just pip install. See Also https://wiki.python.org/moin/WindowsCompilers. I also created ``wmm2020_cext`` on pypi.org. This library has published compiled ".whl" files for Windows Python37-39. Build the wheel files with ``python setup.py bdist_wheel``

Also, removed the static path for WMM.COF and added it as a function argument.

You don't have to add this, but it is really helpful. I couldn't install your library. It looks like it uses MinGW instead of Visual Studio. Python is compiled with Visual Studio on Windows, so the best convention is to compile supporting libraries with Visual Studio for Windows. Also, if you use a C Extension Python will handle the compilation for you. No need for Makefiles. Additionally, the Makefile and build approach installs the .c, .h, and Makefiles with the Python library and forces the user to compile the library. When you compile the C Extension into .whl files you only need to bundle the .py and compiled .pyd files. This allows users to simply pip install unless they are running an OS that you did not compile .whl files for. In that case they can install the Python dev/build tools and pip install. Python will take care of compiling and installing the library which just makes it easier.